### PR TITLE
Change timer to perf_counter

### DIFF
--- a/aioping/__init__.py
+++ b/aioping/__init__.py
@@ -91,7 +91,6 @@ logger = logging.getLogger("aioping")
 default_timer = time.perf_counter
 
 if sys.platform.startswith("win"):
-    # time.clock is deprecated in Python 3.8+
     if sys.version_info[0] > 3 or (sys.version_info[0] == 3 and sys.version_info[1] >= 8):
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 

--- a/aioping/__init__.py
+++ b/aioping/__init__.py
@@ -88,14 +88,12 @@ import uuid
 import random
 
 logger = logging.getLogger("aioping")
-default_timer = time.time
+default_timer = time.perf_counter
 
 if sys.platform.startswith("win"):
     # time.clock is deprecated in Python 3.8+
     if sys.version_info[0] > 3 or (sys.version_info[0] == 3 and sys.version_info[1] >= 8):
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-    else:
-        default_timer = time.clock
 
 # ICMP types, see rfc792 for v4, rfc4443 for v6
 ICMP_ECHO_REQUEST = 8


### PR DESCRIPTION
Right now, aioping is set to use time.time or time.clock for it's ping time. I'm proposing a switch to time.perf_counter, as it has a much higher tick rate than time.time or time.clock. time.perf_counter also includes time during sleep, which time.process_time does not.

https://stackoverflow.com/questions/52222002/what-is-the-difference-between-time-perf-counter-and-time-process-time/52228375

https://www.webucator.com/blog/2015/08/python-clocks-explained/