### PR TITLE
receive_one_ping: fix sign-ness of ICMP type

### DIFF
--- a/aioping/__init__.py
+++ b/aioping/__init__.py
@@ -160,7 +160,7 @@ async def receive_one_ping(my_socket, id_, timeout):
                 icmp_header = rec_packet[offset:offset + 8]
 
                 type, code, checksum, packet_id, sequence = struct.unpack(
-                    "bbHHh", icmp_header
+                    "BbHHh", icmp_header
                 )
 
                 if type != ICMP_ECHO_REPLY and type != ICMP6_ECHO_REPLY:


### PR DESCRIPTION
The ICMP type is unsigned, treating it as signed results in ICMP
ECHO response v6 to be -127 instead of 129