### PR TITLE
Update header unpack formatting to fix ICMPv6 requests

### DIFF
--- a/aioping/__init__.py
+++ b/aioping/__init__.py
@@ -160,7 +160,7 @@ async def receive_one_ping(my_socket, id_, timeout):
                 icmp_header = rec_packet[offset:offset + 8]
 
                 type, code, checksum, packet_id, sequence = struct.unpack(
-                    "bbHHh", icmp_header
+                    "BBHHH", icmp_header
                 )
 
                 if type != ICMP_ECHO_REPLY and type != ICMP6_ECHO_REPLY:
@@ -209,7 +209,7 @@ async def send_one_ping(my_socket, dest_addr, id_, timeout, family):
     my_checksum = 0
 
     # Make a dummy header with a 0 checksum.
-    header = struct.pack("BbHHh", icmp_type, 0, my_checksum, id_, 1)
+    header = struct.pack("BBHHH", icmp_type, 0, my_checksum, id_, 1)
     bytes_in_double = struct.calcsize("d")
     data = (192 - bytes_in_double) * "Q"
     data = struct.pack("d", default_timer()) + data.encode("ascii")
@@ -220,7 +220,7 @@ async def send_one_ping(my_socket, dest_addr, id_, timeout, family):
     # Now that we have the right checksum, we put that in. It's just easier
     # to make up a new header than to stuff it into the dummy.
     header = struct.pack(
-        "BbHHh", icmp_type, 0, socket.htons(my_checksum), id_, 1
+        "BBHHH", icmp_type, 0, socket.htons(my_checksum), id_, 1
     )
     packet = header + data
 


### PR DESCRIPTION
The current header struct format `bbHHh` will cause ICMPv6 response types to be interpreted wrong, which results in a timeout.  Since `ICMP6_ECHO_REPLY = 129` https://github.com/stellarbit/aioping/blob/45102cbaf2dad4e73743a343ef94eee27a09d9d5/aioping/__init__.py#L101 we need to unpack the type as unsigned ([ref](https://docs.python.org/3/library/struct.html#format-characters)) or else the type will never match (129 vs -127) https://github.com/stellarbit/aioping/blob/45102cbaf2dad4e73743a343ef94eee27a09d9d5/aioping/__init__.py#L166.