### PR TITLE
ICMP reply packet type fix

### DIFF
--- a/aioping/__init__.py
+++ b/aioping/__init__.py
@@ -160,7 +160,7 @@ async def receive_one_ping(my_socket, id_, timeout):
                 icmp_header = rec_packet[offset:offset + 8]
 
                 type, code, checksum, packet_id, sequence = struct.unpack(
-                    "bbHHh", icmp_header
+                    "BbHHh", icmp_header
                 )
 
                 if type != ICMP_ECHO_REPLY and type != ICMP6_ECHO_REPLY:


### PR DESCRIPTION
According to IANA (https://www.iana.org/assignments/icmpv6-parameters/icmpv6-parameters.txt), ICMPv6 packet type is unsigned char.

Without the fix, pings to IPv6 addresses raise timeout exception:

```
> ./bin/python -m unittest discover 2>&1 | grep -E 'ERROR.*(google|heise)'
ERROR:aioping:google.com timed out after 2s
ERROR:aioping:heise.de timed out after 2s
ERROR:aioping:google.com timed out after 2s
ERROR:aioping:heise.de timed out after 2s
ERROR:aioping:google.com timed out after 2s
ERROR:aioping:heise.de timed out after 2s
```
After the fix, unit tests are OK.